### PR TITLE
Doc: typos for toaste(r) get changed to toastr

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ import VueNotifications from 'vue-notifications'
 import miniToastr from 'mini-toastr'
 ```
 
-P.S. don't forget to install `mini-toaste` \(`npm i mini-toastr --save`\)
+P.S. don't forget to install `mini-toastr` \(`npm i mini-toastr --save`\)
 
 * Setup types of the messages
 

--- a/docs/html/getting-started.html
+++ b/docs/html/getting-started.html
@@ -286,11 +286,11 @@ Vue.use(VueNotifications, options)
 <ul>
 <li>Import <code>vue-notifications</code></li>
 </ul>
-<p>Here we&apos;re including <code>vue-notifications</code> and  <code>mini-toaster</code> in our project</p>
+<p>Here we&apos;re including <code>vue-notifications</code> and  <code>mini-toastr</code> in our project</p>
 <pre><code class="lang-js"><span class="hljs-keyword">import</span> VueNotifications <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;vue-notifications&apos;</span>
 <span class="hljs-keyword">import</span> miniToastr <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;mini-toastr&apos;</span>
 </code></pre>
-<p>P.S. don&apos;t forget to install <code>mini-toaste</code> (<code>npm i mini-toastr --save</code>)</p>
+<p>P.S. don&apos;t forget to install <code>mini-toastr</code> (<code>npm i mini-toastr --save</code>)</p>
 <ul>
 <li>Setup types of the messages</li>
 </ul>
@@ -334,7 +334,7 @@ Vue.use(VueNotifications, options)
 <p>You can just copy-paste code below</p>
 <pre><code class="lang-js"><span class="hljs-keyword">import</span> VueNotifications <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;vue-notifications&apos;</span>
 
-<span class="hljs-comment">// Include mini-toaster (or any other UI-notification library)</span>
+<span class="hljs-comment">// Include mini-toastr (or any other UI-notification library)</span>
 <span class="hljs-keyword">import</span> miniToastr <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;mini-toastr&apos;</span>
 
 <span class="hljs-comment">// We shall setup types of the messages. (&apos;error&apos; type - red and &apos;success&apos; - green in mini-toastr)</span>

--- a/docs/md/getting-started.md
+++ b/docs/md/getting-started.md
@@ -92,7 +92,7 @@ You can just copy-paste code below
 ```js
 import VueNotifications from 'vue-notifications'
 
-// Include mini-toaster (or any other UI-notification library)
+// Include mini-toastr (or any other UI-notification library)
 import miniToastr from 'mini-toastr'
 
 // We shall setup types of the messages. ('error' type - red and 'success' - green in mini-toastr)

--- a/docs/md/getting-started.md
+++ b/docs/md/getting-started.md
@@ -28,14 +28,14 @@ Anyway
 
 * Import `vue-notifications`
 
-Here we're including `vue-notifications` and  `mini-toaster` in our project
+Here we're including `vue-notifications` and  `mini-toastr` in our project
 
 ```js
 import VueNotifications from 'vue-notifications'
 import miniToastr from 'mini-toastr'
 ```
 
-P.S. don't forget to install `mini-toaste` \(`npm i mini-toastr --save`\)
+P.S. don't forget to install `mini-toastr` \(`npm i mini-toastr --save`\)
 
 * Setup types of the messages
 


### PR DESCRIPTION
`toastr` without `e` now used consistently.
`mini-toastr` kebap-case and camelCase for `miniToastr` were fine already!